### PR TITLE
added load button to GUI

### DIFF
--- a/src/napari_vedo_bridge/_cutter_widget.py
+++ b/src/napari_vedo_bridge/_cutter_widget.py
@@ -1,9 +1,11 @@
 from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 from vedo import Plotter, Mesh, dataurl, Axes
+import vedo
 import os
 from pathlib import Path
 from qtpy import uic
 from qtpy.QtWidgets import QWidget
+from qtpy.QtWidgets import QFileDialog
 import numpy as np
 from magicgui import magicgui
 
@@ -30,6 +32,7 @@ class VedoCutter(QWidget):
         self.pushButton_box_cutter.clicked.connect(self.box_cutter_tool)
         self.pushButton_sphere_cutter.clicked.connect(self.sphere_cutter_tool)
         self.pushButton_plane_cutter.clicked.connect(self.plane_cutter_tool)
+        self.pushButton_load_mesh.clicked.connect(self._load_mesh)
 
         self.plane_cutter_widget = None
         self.box_cutter_widget = None
@@ -118,3 +121,21 @@ class VedoCutter(QWidget):
             self.sphere_cutter_widget = self.plt.cutter_widget
         else:
             self.sphere_cutter_widget.Off()
+
+    def _load_mesh(self):
+        """
+        Opens a file dialog to load a mesh file.
+        """
+        filename = QFileDialog.getOpenFileName(
+            caption='Open mesh file',
+            filter='Mesh files (*.obj *.ply *.stl *.vtk *.vtp)'
+        )
+
+        self.mesh = vedo.load(filename[0])
+        if len(self.plt.actors) > 0:
+            self.plt.clear(deep=True)
+    
+        #self.plt += Axes(self.mesh, c='white')
+        self.plt += self.mesh
+        self.plt.reset_camera()
+

--- a/src/napari_vedo_bridge/vedo_extension.ui
+++ b/src/napari_vedo_bridge/vedo_extension.ui
@@ -7,56 +7,63 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>432</height>
+    <height>396</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Vedo viewer</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QPushButton" name="pushButton_plane_cutter">
-         <property name="text">
-          <string>Plane cutter</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_box_cutter">
-         <property name="text">
-          <string>Box cutter</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton_sphere_cutter">
-         <property name="text">
-          <string>Sphere cutter</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="checkBox_invert">
-       <property name="enabled">
+      <widget class="QPushButton" name="pushButton_plane_cutter">
+       <property name="text">
+        <string>Plane cutter</string>
+       </property>
+       <property name="checkable">
         <bool>true</bool>
        </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_box_cutter">
        <property name="text">
-        <string>Invert</string>
+        <string>Box cutter</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_sphere_cutter">
+       <property name="text">
+        <string>Sphere cutter</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBox_invert">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Invert</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="pushButton_load_mesh">
+       <property name="text">
+        <string>Load mesh</string>
        </property>
       </widget>
      </item>
@@ -67,14 +74,14 @@
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QPushButton" name="pushButton_send_back">
-       <property name="text">
-        <string>Send back to napari</string>
-       </property>
-      </widget>
-     </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QPushButton" name="pushButton_send_back">
+     <property name="text">
+      <string>Send back to napari</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
For #5 

Adds a load button to the GUI. Small problem: If I add the axes to the plotter [here](https://github.com/jo-mueller/napari-vedo-bridge/blob/9338d79bf60d93466cba761ef164e9162812c8d5/src/napari_vedo_bridge/_cutter_widget.py#L138), I get an error when I want to send the mesh to napari because the GUI currently only sends the last added actor back to napari (or tries to).

We should make sure we only send actors of type `Mesh` back in the `send_to_napari` function.