### PR TITLE
Remove unused UI elements

### DIFF
--- a/src/napari_vedo_bridge/_cutter_widget.py
+++ b/src/napari_vedo_bridge/_cutter_widget.py
@@ -24,7 +24,7 @@ class VedoCutter(QWidget):
         self.mesh_color = "yellow6"
         self.mesh_backcolor = "purple7"
         self.mesh_lighting = "shiny"
-    
+
         self.vedo_message = Text2D(font='Calco', c='white')
         self.vedo_axes = None
 
@@ -45,7 +45,7 @@ class VedoCutter(QWidget):
         self.plt = Plotter(qt_widget=self.vtkWidget, bg='bb', interactive=False)
         self.plt += self.vedo_message
         self.plt += Text2D(
-            "vedo "+_vedo_version,
+            "vedo " + _vedo_version,
             pos='top-right',
             font='Calco',
             c='k5',
@@ -53,11 +53,10 @@ class VedoCutter(QWidget):
         )
         self.plt.show()
 
-
     def get_from_napari(self):
         """
         Get the currently selected layer from napari and display it in vedo
-        """        
+        """
         if self.cutter_widget:
             self.plt.remove(self.cutter_widget)
         self.plt.remove(self.mesh, self.vedo_axes)
@@ -67,12 +66,12 @@ class VedoCutter(QWidget):
             points = self.currently_selected_layer.data[0].astype(float)
             faces = self.currently_selected_layer.data[1].astype(int)
             scalars = self.currently_selected_layer.data[2]
-            self.mesh = Mesh([points, faces])  # only vertices and faces       
+            self.mesh = Mesh([points, faces])  # only vertices and faces
             if len(scalars) > 0:
                 self.mesh.pointdata['scalars'] = scalars
         else:
             # TEST mesh
-            self.mesh = Mesh(dataurl+"mouse_brain.stl")
+            self.mesh = Mesh(dataurl + "mouse_brain.stl")
 
         self.mesh.c(self.mesh_color)
         self.mesh.backcolor(self.mesh_backcolor)
@@ -138,7 +137,7 @@ class VedoCutter(QWidget):
                 'Press spacebar to toggle the cutter on/off\n'
                 'Press i to invert the selection\n',
             )
-        
+
         self.plt.render()
 
     def plane_cutter_tool(self):
@@ -166,7 +165,6 @@ class VedoCutter(QWidget):
         if self.cutter_widget is not None:
             self.plt.remove(self.cutter_widget)
             self.cutter_widget = None
-
 
     def _load_mesh(self):
         """

--- a/src/napari_vedo_bridge/_cutter_widget.py
+++ b/src/napari_vedo_bridge/_cutter_widget.py
@@ -149,12 +149,18 @@ class VedoCutter(QWidget):
         """
         Add a plane cutter tool to the vedo plotter
         """
+        self.vedo_message.text(
+            "Coming soon!")
+        self.plt.render()
         pass
 
     def sphere_cutter_tool(self):
         """
         Add a sphere cutter tool to the vedo plotter
         """
+        self.vedo_message.text(
+            "Coming soon!")
+        self.plt.render()
         pass
 
 

--- a/src/napari_vedo_bridge/_cutter_widget.py
+++ b/src/napari_vedo_bridge/_cutter_widget.py
@@ -135,10 +135,7 @@ class VedoCutter(QWidget):
 
         # add new cutter
         if self.pushButton_box_cutter.isChecked():
-            self.cutter_widget = BoxCutter(
-                self.mesh,
-                invert=self.checkBox_invert.isChecked(),
-            )
+            self.cutter_widget = BoxCutter(self.mesh)
             self.plt.add(self.cutter_widget)
             self.vedo_message.text(
                 "Press r to reset the cutter\n"

--- a/src/napari_vedo_bridge/_cutter_widget.py
+++ b/src/napari_vedo_bridge/_cutter_widget.py
@@ -128,12 +128,8 @@ class VedoCutter(QWidget):
             self.plt.render()
             return
 
-        # remove old cutter
-        if self.cutter_widget is not None:
-            self.plt.remove(self.cutter_widget)
-            self.cutter_widget = None
-
         # add new cutter
+        self._remove_cutter()  # remove old cutter
         if self.pushButton_box_cutter.isChecked():
             self.cutter_widget = BoxCutter(self.mesh)
             self.plt.add(self.cutter_widget)
@@ -149,6 +145,7 @@ class VedoCutter(QWidget):
         """
         Add a plane cutter tool to the vedo plotter
         """
+        self._remove_cutter()  # remove old cutter
         self.vedo_message.text(
             "Coming soon!")
         self.plt.render()
@@ -158,10 +155,17 @@ class VedoCutter(QWidget):
         """
         Add a sphere cutter tool to the vedo plotter
         """
+        self._remove_cutter()  # remove old cutter
         self.vedo_message.text(
             "Coming soon!")
         self.plt.render()
         pass
+
+    def _remove_cutter(self):
+        # remove old cutter
+        if self.cutter_widget is not None:
+            self.plt.remove(self.cutter_widget)
+            self.cutter_widget = None
 
 
     def _load_mesh(self):

--- a/src/napari_vedo_bridge/vedo_extension.ui
+++ b/src/napari_vedo_bridge/vedo_extension.ui
@@ -49,16 +49,6 @@
     </layout>
    </item>
    <item>
-    <widget class="QCheckBox" name="checkBox_invert">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="text">
-      <string>Invert</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QPushButton" name="pushButton_load_mesh">

--- a/src/napari_vedo_bridge/vedo_extension.ui
+++ b/src/napari_vedo_bridge/vedo_extension.ui
@@ -15,66 +15,88 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="pushButton_plane_cutter">
-       <property name="text">
-        <string>Plane cutter</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButton_box_cutter">
-       <property name="text">
-        <string>Box cutter</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButton_sphere_cutter">
-       <property name="text">
-        <string>Sphere cutter</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QPushButton" name="pushButton_load_mesh">
-       <property name="text">
-        <string>Load mesh</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushButton_get_from_napari">
-       <property name="text">
-        <string>Retrieve mesh from napari</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QPushButton" name="pushButton_send_back">
-     <property name="text">
-      <string>Send back to napari</string>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Cutting tools</string>
      </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QPushButton" name="pushButton_plane_cutter">
+        <property name="text">
+         <string>Plane cutter</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButton_box_cutter">
+        <property name="text">
+         <string>Box cutter</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButton_sphere_cutter">
+        <property name="text">
+         <string>Sphere cutter</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Data</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QPushButton" name="pushButton_load_mesh">
+        <property name="text">
+         <string>Load mesh</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="pushButton_get_from_napari">
+        <property name="text">
+         <string>Retrieve mesh from napari</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QPushButton" name="pushButton_send_back">
+        <property name="text">
+         <string>Send back to napari</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
Hi @marcomusy 

This PR

- removes the invert button
- Adds the three cutter buttons to a QButtonGroup (which I doscovered today) which makes the three buttons mutually exclusive, i.e. unchecks two of them if one is clicked.
- Adds a "Coming soon" message to the currently unimplemented cutter tools
- Adds group boxes around the three cutter button and the three data loading/sending/retrieving buttons
- Adds a small convenience function to remove cutters if any of the buttons has been clicked.