### PR TITLE
request current vedo version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     numpy
     magicgui
     qtpy
-    vedo
+    vedo @ git+https://github.com/marcomusy/vedo.git
 
 python_requires = >=3.8
 include_package_data = True


### PR DESCRIPTION
This changes the version of vedo in the dependencies to the version from the github repo. Until all new changes to vedo are released, this should make the plugin functional on other PCs.