### PR TITLE
Used new vedo version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     numpy
     magicgui
     qtpy
-    vedo @ git+https://github.com/marcomusy/vedo.git
+    vedo>=2023.4.6
 
 python_requires = >=3.8
 include_package_data = True


### PR DESCRIPTION
This changes the dependencies to only use the newer vedo version (`2023.4.6`)

Should be merged for release #12 