### PR TITLE
Add more basic vedo viewer

### DIFF
--- a/src/napari_vedo_bridge/__init__.py
+++ b/src/napari_vedo_bridge/__init__.py
@@ -35,4 +35,5 @@ __all__ = [
     "binarize",
     "smooth_points",
     "remove_outliers"
+    "widgets",
 ]

--- a/src/napari_vedo_bridge/__init__.py
+++ b/src/napari_vedo_bridge/__init__.py
@@ -35,5 +35,6 @@ __all__ = [
     "binarize",
     "smooth_points",
     "remove_outliers"
+    "smooth_mls_1d",
     "widgets",
 ]

--- a/src/napari_vedo_bridge/__init__.py
+++ b/src/napari_vedo_bridge/__init__.py
@@ -19,6 +19,8 @@ from ._points import (
     remove_outliers,
 )
 
+from . import _widgets as widgets
+
 __all__ = [
     "compute_normals",
     "shrink",

--- a/src/napari_vedo_bridge/_tests/test_widget.py
+++ b/src/napari_vedo_bridge/_tests/test_widget.py
@@ -1,4 +1,5 @@
 import numpy as np
+import vedo
 from .._cutter_widget import VedoCutter
 
 
@@ -15,7 +16,6 @@ def test_cutter_widget(make_napari_viewer):
 
 def test_get_from_napari(make_napari_viewer):
     # Load the test mesh into the napari viewer
-    import vedo
     viewer = make_napari_viewer()
     mesh = vedo.load("https://vedo.embl.es/examples/data/270.vtk")
     viewer.add_surface((mesh.vertices, np.asarray(mesh.cells)), name="test_mesh")
@@ -32,7 +32,6 @@ def test_get_from_napari(make_napari_viewer):
 
 
 def test_cutters(make_napari_viewer):
-    import vedo
     viewer = make_napari_viewer()
     mesh = vedo.load("https://vedo.embl.es/examples/data/270.vtk")
     viewer.add_surface((mesh.vertices, np.asarray(mesh.cells)), name="test_mesh")
@@ -51,3 +50,34 @@ def test_cutters(make_napari_viewer):
     vedo_cutter.buttonGroup.buttons()[2].click()
     n_checked_buttons = len([b for b in vedo_cutter.buttonGroup.buttons() if b.isChecked()])
     assert n_checked_buttons == 1
+
+
+def base_widget(make_napari_viewer):
+    from napari_vedo_bridge._widgets.base_widget import BaseWidget
+    viewer = make_napari_viewer()
+
+    n_widgets = len(viewer.window._dock_widgets)
+
+    mesh = vedo.load("https://vedo.embl.es/examples/data/270.vtk")
+    viewer.add_surface((mesh.vertices, np.asarray(mesh.cells)), name="test_mesh")
+    n_layers = len(viewer.layers)
+
+    base_widget = BaseWidget(viewer)
+    viewer.window.add_dock_widget(base_widget, area='right')
+
+    assert len(viewer.window._dock_widgets) == n_widgets + 1
+
+    base_widget.pushButton_get_from_napari.click()
+    assert base_widget.mesh is not None
+
+    base_widget.pushButton_send_back.click()
+    assert len(viewer.layers) == n_layers + 1
+
+    base_widget.pushButton_clear.click()
+    assert base_widget.mesh is None
+
+    base_widget.pushButton_show_hotkeys.click()
+    assert len(viewer.window._dock_widgets) == n_widgets + 2
+
+
+

--- a/src/napari_vedo_bridge/_widgets/__init__.py
+++ b/src/napari_vedo_bridge/_widgets/__init__.py
@@ -1,0 +1,4 @@
+from .base_widget import VedoWidget, VedoHotkeyreference
+
+__all__ = ['VedoWidget',
+           'VedoHotkeyreference']

--- a/src/napari_vedo_bridge/_widgets/base_widget.py
+++ b/src/napari_vedo_bridge/_widgets/base_widget.py
@@ -1,0 +1,187 @@
+import napari.utils
+from qtpy import uic, QtWidgets
+from PyQt5.QtCore import QObject, pyqtSignal, Qt
+
+from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
+import napari
+import numpy as np
+import sys
+import os
+from pathlib import Path
+
+from vedo import Plotter, Mesh, settings, Text2D
+from vedo import __version__ as _vedo_version
+
+settings.default_backend = 'vtk'
+
+
+class EmittingStream(QObject):
+    textWritten = pyqtSignal(str)
+
+    def write(self, text):
+        self.textWritten.emit(str(text))
+
+    def flush(self):
+        pass
+
+
+class VedoWidget(QtWidgets.QWidget):
+    def __init__(self, napari_viewer: napari.Viewer):
+        super().__init__()
+        self.napari_viewer = napari_viewer
+
+        self._setup_ui()
+        self._connect_signals()
+
+        self.plt = Plotter(qt_widget=self.vtk_widget, interactive=True, axes=2, bg='bb')
+        self._show_relevant_text()
+        self.plt.show()
+        self.mesh = None
+
+    def _setup_ui(self):
+
+        uic.loadUi(
+            os.path.join(Path(__file__).parent, "./base_widget.ui"),
+            self
+            )
+
+        # insert vtk widget at the top
+        self.vtk_widget = QVTKRenderWindowInteractor()
+        self.layout().insertWidget(0, self.vtk_widget)
+
+    def _connect_signals(self):
+        self.pushButton_get_from_napari.clicked.connect(self._from_napari)
+        self.pushButton_send_back.clicked.connect(self._to_napari)
+        self.pushButton_clear.clicked.connect(self._clear)
+        self.pushButton_show_hotkeys.clicked.connect(self._show_hotkey_reference)
+
+        # connect stdout to text edit
+        sys.stdout = EmittingStream(textWritten=self._collect_stdout)
+
+    def _from_napari(self):
+        selected_layers = self.napari_viewer.layers.selection.active
+
+        if not isinstance(selected_layers, napari.layers.Surface):
+            # throw napari warning
+            napari.utils.notifications.Notification(
+                title="Invalid Layer",
+                message="Please select a surface layer",
+                duration=2
+            ).send()
+            return
+
+        self.mesh = Mesh(selected_layers.data[:2])  # only vertices and faces
+        text = Text2D(
+            "Layer: " + selected_layers.name,
+            pos='top-left',
+            font='Calco',
+            c='k5',
+            s=0.5,
+        )
+        self.plt += [text, self.mesh]
+        self.plt.render()
+
+        self.status_text_edit.appendPlainText(f"Mesh: {selected_layers.name}")
+
+    def _to_napari(self):
+        """
+        Get mesh data from the plotter and send back
+        """
+        if self.mesh is None:
+            return
+
+        # get vertices and faces
+        vertices, faces = self.mesh.vertices, self.mesh.cells
+        layer = napari.layers.Surface((vertices, np.asarray(faces)))
+        self.napari_viewer.add_layer(layer)
+
+        self.status_text_edit.appendPlainText(f"Sent to Napari: {layer.name}")
+
+    def _show_relevant_text(self):
+        self.plt += Text2D(
+            "vedo " + _vedo_version,
+            pos='bottom-right',
+            font='Calco',
+            c='k5',
+            s=0.5,
+        )
+
+    def _show_hotkey_reference(self):
+        hotkey_reference = VedoHotkeyreference(self.napari_viewer)
+        self.napari_viewer.window.add_dock_widget(hotkey_reference, area='right')
+
+    def _clear(self):
+        self.plt.clear()
+        [self.plt.remove(actor) for actor in self.plt.actors]
+        self._show_relevant_text()
+        self.plt.render()
+        self.mesh = None
+
+        self.status_text_edit.clear()
+
+    def _collect_stdout(self, text):
+        self.status_text_edit.appendPlainText(text)
+
+
+class VedoHotkeyreference(QtWidgets.QWidget):
+    def __init__(self, napari_viewer: napari.Viewer):
+        super().__init__()
+
+        self._setup_ui()
+
+    def _setup_ui(self):
+        self.layout = QtWidgets.QVBoxLayout()
+
+        # Create a QTableWidget
+        self.hotkey_table = QtWidgets.QTableWidget()
+        self.hotkey_table.setRowCount(28)  # Number of hotkeys
+        self.hotkey_table.setColumnCount(2)  # Hotkey and description
+        self.hotkey_table.setHorizontalHeaderLabels(["Hotkey", "Description"])
+        self.hotkey_table.verticalHeader().setVisible(False)
+        self.hotkey_table.horizontalHeader().setStretchLastSection(True)
+
+        # Hotkey descriptions
+        hotkeys = [
+            ("i", "print info about the last clicked object"),
+            ("I", "print color of the pixel under the mouse"),
+            ("Y", "show the pipeline for this object as a graph"),
+            ("<- ->", "use arrows to reduce/increase opacity"),
+            ("x", "toggle mesh visibility"),
+            ("w", "toggle wireframe/surface style"),
+            ("l", "toggle surface edges visibility"),
+            ("p/P", "hide surface faces and show only points"),
+            ("1-3", "cycle surface color (2=light, 3=dark)"),
+            ("4", "cycle color map (press shift-4 to go back)"),
+            ("5-6", "cycle point-cell arrays (shift to go back)"),
+            ("7-8", "cycle background and gradient color"),
+            ("09+-", "cycle axes styles (on keypad, or press +/-)"),
+            ("k", "cycle available lighting styles"),
+            ("K", "toggle shading as flat or phong"),
+            ("A", "toggle anti-aliasing"),
+            ("D", "toggle depth-peeling (for transparencies)"),
+            ("U", "toggle perspective/parallel projection"),
+            ("o/O", "toggle extra light to scene and rotate it"),
+            ("a", "toggle interaction to Actor Mode"),
+            ("n", "toggle surface normals"),
+            ("r", "reset camera position"),
+            ("R", "reset camera to the closest orthogonal view"),
+            (".", "fly camera to the last clicked point"),
+            ("C", "print the current camera parameters state"),
+            ("X", "invoke a cutter widget tool"),
+            ("S", "save a screenshot of the current scene"),
+            ("E/F", "export 3D scene to numpy file or X3D"),
+            ("q", "return control to python script"),
+            ("Esc", "abort execution and exit python kernel"),
+        ]
+
+        # Populate the table
+        for row, (hotkey, description) in enumerate(hotkeys):
+            hotkey_item = QtWidgets.QTableWidgetItem(hotkey)
+            description_item = QtWidgets.QTableWidgetItem(description)
+            hotkey_item.setFlags(hotkey_item.flags() & ~Qt.ItemIsEditable)
+            description_item.setFlags(description_item.flags() & ~Qt.ItemIsEditable)
+            self.hotkey_table.setItem(row, 0, hotkey_item)
+            self.hotkey_table.setItem(row, 1, description_item)
+
+        self.layout.addWidget(self.hotkey_table)
+        self.setLayout(self.layout)

--- a/src/napari_vedo_bridge/_widgets/base_widget.ui
+++ b/src/napari_vedo_bridge/_widgets/base_widget.ui
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="0">
+      <widget class="QPushButton" name="pushButton_get_from_napari">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Get from napari</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QPushButton" name="pushButton_send_back">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Send to napari</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QPushButton" name="pushButton_clear">
+       <property name="text">
+        <string>Clear</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QPushButton" name="pushButton_show_hotkeys">
+       <property name="text">
+        <string>Hotkeys</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Status</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QPlainTextEdit" name="status_text_edit">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/napari_vedo_bridge/napari.yaml
+++ b/src/napari_vedo_bridge/napari.yaml
@@ -2,6 +2,9 @@ name: napari-vedo-bridge
 display_name: napari vedo bridge
 contributions:
   commands:
+    - id: napari-vedo-bridge.vedo_viewer
+      python_name: napari_vedo_bridge._widgets:VedoWidget
+      title: Vedo mesh viusdalization widget
     - id: napari-vedo-bridge.cutter_widget
       python_name: napari_vedo_bridge._cutter_widget:VedoCutter
       title: Interactive mesh cutting with Vedo
@@ -64,6 +67,9 @@ contributions:
     - command: napari-vedo-bridge.cutter_widget
       display_name: Mesh cutter
       autogenerate: true
+    - command: napari-vedo-bridge.vedo_viewer
+      display_name: Vedo mesh viewer
+
     - command: napari-vedo-bridge.compute_normals
       display_name: Compute normals
     - command: napari-vedo-bridge.shrink
@@ -97,6 +103,9 @@ contributions:
       - command: napari-vedo-bridge.load_surfaces
       - command: napari-vedo-bridge.write_points
       - command: napari-vedo-bridge.write_surfaces
+
+    napari/layers/visualize:
+      - command: napari-vedo-bridge.vedo_viewer
 
     napari/layers/transform:
       - command: napari-vedo-bridge.cutter_widget


### PR DESCRIPTION
This adds a more basic, extensible `VedoWidget` to the functionality of the vedo bridge. Essentially, it wraps the vedo `Plotter` and some essential function (sending meshes back and forth between napari and vedo).

Other functionality, buttons, etc. can latter be added in derived widgets.