### PR TITLE
remove forbidden pyqt5

### DIFF
--- a/src/napari_vedo_bridge/_widgets/base_widget.py
+++ b/src/napari_vedo_bridge/_widgets/base_widget.py
@@ -16,7 +16,7 @@ settings.default_backend = 'vtk'
 
 
 class EmittingStream(QObject):
-    textWritten = pyqtSignal(str)
+    textWritten = Signal(str)
 
     def write(self, text):
         self.textWritten.emit(str(text))

--- a/src/napari_vedo_bridge/_widgets/base_widget.py
+++ b/src/napari_vedo_bridge/_widgets/base_widget.py
@@ -1,6 +1,6 @@
 import napari.utils
 from qtpy import uic, QtWidgets
-from PyQt5.QtCore import QObject, pyqtSignal, Qt
+from qtpy.QtCore import QObject, Signal, Qt
 
 from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 import napari


### PR DESCRIPTION
This pull request includes a change to the `src/napari_vedo_bridge/_widgets/base_widget.py` file to improve compatibility with `qtpy` by replacing `PyQt5` imports with `qtpy` equivalents.

Compatibility improvements:

* [`src/napari_vedo_bridge/_widgets/base_widget.py`](diffhunk://#diff-a0d6db6aca90aad898a6a1e7badb482eba5275303443f1370eeac4f707214167L3-R3): Replaced `PyQt5` imports with `qtpy` equivalents for `QObject`, `Signal`, and `Qt`.