### PR TITLE
update actions and versions

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -20,16 +20,17 @@ jobs:
   test:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -54,7 +55,7 @@ jobs:
 
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
-        uses: aganders3/headless-gui@v1
+        uses: aganders3/headless-gui@v2
         with:
           run: python -m tox
         env:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310,311}-{linux,macos,windows}
+envlist = py{39,310,311,312,313}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
@@ -8,6 +8,8 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration and the `tox` configuration to support additional Python versions and update dependencies. The most important changes include adding support for Python 3.12 and 3.13, updating the actions versions, and setting a timeout for the test jobs.

Updates to GitHub Actions workflow:

* [`.github/workflows/test_and_deploy.yml`](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804R23-R33): Added support for Python 3.12 and 3.13 in the `matrix.python-version`.
* [`.github/workflows/test_and_deploy.yml`](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804R23-R33): Updated `actions/checkout` to version 4 and `actions/setup-python` to version 5.
* [`.github/workflows/test_and_deploy.yml`](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804R23-R33): Set a timeout of 30 minutes for the test jobs.
* [`.github/workflows/test_and_deploy.yml`](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804L57-R58): Updated `aganders3/headless-gui` to version 2.

Updates to `tox` configuration:

* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L3-R12): Added support for Python 3.12 and 3.13 in the `envlist` and `gh-actions` sections.