### PR TITLE
Fix point smoothing annd add 2d algorithm

### DIFF
--- a/src/napari_vedo_bridge/_points.py
+++ b/src/napari_vedo_bridge/_points.py
@@ -47,6 +47,40 @@ def smooth_mls_1d(
         radius=radius)
     return vedo_points_to_napari(vedo_points)
 
+@magic_factory(
+    points={'label': 'Points'},
+    widget_init=_on_init
+)
+def smooth_mls_2d(
+        points: Points,
+        factor: float = 0.2,
+        radius: Optional[float] = 0) -> Points:
+    """
+    Smooth the given points in 2D.
+
+    Parameters
+    ----------
+    points : Points
+        The input points.
+    factor : float, optional
+        The smoothing factor, by default 0.2.
+    radius : float, optional
+        The radius for smoothing, by default 0.
+
+    Returns
+    -------
+    Points
+        The smoothed points.
+    """
+    vedo_points = napari_to_vedo_points(points)
+    vedo_points.smooth_mls_2d(
+        f=factor,
+        radius=radius)
+    new_points = vedo_points_to_napari(vedo_points)
+    new_points.scale = points.scale
+    new_points.size = points.size
+    new_points.translate = points.translate
+    return new_points
 
 @magic_factory(
     points={'label': 'Points'},

--- a/src/napari_vedo_bridge/_points.py
+++ b/src/napari_vedo_bridge/_points.py
@@ -46,7 +46,11 @@ def smooth_mls_1d(
     vedo_points.smooth_mls_1d(
         f=factor,
         radius=radius)
-    return vedo_points_to_napari(vedo_points)
+    new_points = vedo_points_to_napari(vedo_points)
+    new_points.scale = points.scale
+    new_points.size = points.size
+    new_points.translate = points.translate
+    return new_points
 
 @magic_factory(
     points={'label': 'Points'},

--- a/src/napari_vedo_bridge/_points.py
+++ b/src/napari_vedo_bridge/_points.py
@@ -4,6 +4,7 @@ from napari_vedo_bridge.utils import napari_to_vedo_points, vedo_points_to_napar
 from napari.layers import Points
 from magicgui import widgets, magic_factory
 from qtpy.QtCore import Qt
+from typing import Optional
 
 
 def _on_init(widget):
@@ -23,7 +24,7 @@ def _on_init(widget):
 def smooth_mls_1d(
         points: Points,
         factor: float = 0.2,
-        radius: float = 0) -> Points:
+        radius: Optional[float] = 0) -> Points:
     """
     Smooth the given points.
 

--- a/src/napari_vedo_bridge/_points.py
+++ b/src/napari_vedo_bridge/_points.py
@@ -9,7 +9,7 @@ from qtpy.QtCore import Qt
 def _on_init(widget):
     label_widget = widgets.Label(value='')
     func_name = widget.label.split(' ')[0]
-    label_widget.value = f'<a href=\"https://vedo.embl.es/docs/vedo/pointcloud.html#Points.{func_name}\">skimage.filters.{func_name}</a>'
+    label_widget.value = f'<a href=\"https://vedo.embl.es/docs/vedo/pointcloud.html#Points.{func_name}\">vedo.Points.{func_name}</a>'
     label_widget.native.setTextFormat(Qt.RichText)
     label_widget.native.setTextInteractionFlags(Qt.TextBrowserInteraction)
     label_widget.native.setOpenExternalLinks(True)

--- a/src/napari_vedo_bridge/_tests/test_points.py
+++ b/src/napari_vedo_bridge/_tests/test_points.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from napari_vedo_bridge._points import smooth_mls_1d, remove_outliers
+from napari_vedo_bridge._points import smooth_mls_1d, smooth_mls_2d, remove_outliers
 from napari.layers import Points
 
 
@@ -13,6 +13,9 @@ def test_smooth_points(sample_points):
     smoothed_points = smooth_mls_1d()(sample_points, factor=0.2, radius=0)
     assert smoothed_points.data.shape == sample_points.data.shape
 
+def smooth_points_2d(sample_points):
+    smoothed_points = smooth_mls_2d()(sample_points, factor=0.2, radius=0)
+    assert smoothed_points.data.shape == sample_points.data.shape
 
 def test_remove_outliers(sample_points):
     # add a far-out point

--- a/src/napari_vedo_bridge/napari.yaml
+++ b/src/napari_vedo_bridge/napari.yaml
@@ -57,9 +57,12 @@ contributions:
     - id: napari-vedo-bridge.binarize
       python_name: napari_vedo_bridge._mesh:binarize
       title: Binarize surface
-    - id: napari-vedo-bridge.smooth_points
-      python_name: napari_vedo_bridge._points:smooth_points
-      title: Smooth points
+    - id: napari-vedo-bridge.smooth_points_1d
+      python_name: napari_vedo_bridge._points:smooth_mls_1d
+      title: Smooth points (moving lest-squares 1D)
+    - id: napari-vedo-bridge.smooth_points_2d
+      python_name: napari_vedo_bridge._points:smooth_mls_2d
+      title: Smooth points (moving least-squares 2D)
     - id: napari-vedo-bridge.remove_outliers
       python_name: napari_vedo_bridge._points:remove_outliers
       title: Remove outliers from points
@@ -147,6 +150,8 @@ contributions:
       display_name: Binarize mesh
     - command: napari-vedo-bridge.smooth_points
       display_name: Smooth points
+    - command: napari-vedo-bridge.smooth_points_2d
+      display_name: Smooth points (moving least-squares 2D)
     - command: napari-vedo-bridge.remove_outliers
       display_name: Remove outliers
 
@@ -174,6 +179,7 @@ contributions:
       - command: napari-vedo-bridge.decimate_pro
       - command: napari-vedo-bridge.decimate_binned
       - command: napari-vedo-bridge.smooth_points
+      - command: napari-vedo-bridge.smooth_points_2d
 
     napari/layers/segment:
       - command: napari-vedo-bridge.extract_largest_region

--- a/src/napari_vedo_bridge/napari.yaml
+++ b/src/napari_vedo_bridge/napari.yaml
@@ -148,8 +148,8 @@ contributions:
       display_name: Extract largest region
     - command: napari-vedo-bridge.binarize
       display_name: Binarize mesh
-    - command: napari-vedo-bridge.smooth_points
-      display_name: Smooth points
+    - command: napari-vedo-bridge.smooth_points_1d
+      display_name: Smooth points (moving least-squares 1D)
     - command: napari-vedo-bridge.smooth_points_2d
       display_name: Smooth points (moving least-squares 2D)
     - command: napari-vedo-bridge.remove_outliers
@@ -178,7 +178,7 @@ contributions:
       - command: napari-vedo-bridge.decimate
       - command: napari-vedo-bridge.decimate_pro
       - command: napari-vedo-bridge.decimate_binned
-      - command: napari-vedo-bridge.smooth_points
+      - command: napari-vedo-bridge.smooth_points_1d
       - command: napari-vedo-bridge.smooth_points_2d
 
     napari/layers/segment:


### PR DESCRIPTION
This pull request introduces enhancements to the `napari_vedo_bridge` package, focusing on improving point smoothing functionality and updating the package's contributions metadata. The most significant changes include the addition of a new 2D smoothing function, updates to existing smoothing logic, and corresponding adjustments to the package's YAML configuration and tests.

### Enhancements to point smoothing functionality:

* **Updated `smooth_mls_1d` function**: Modified the `radius` parameter to accept `Optional[float]` and ensured that the returned points preserve properties like `scale`, `size`, and `translate`. (`src/napari_vedo_bridge/_points.py`, [[1]](diffhunk://#diff-54dbbd9453c28f9421c6b963083251446978e7cb794ab9567d2fa2cb2126b3afL26-R27) [[2]](diffhunk://#diff-54dbbd9453c28f9421c6b963083251446978e7cb794ab9567d2fa2cb2126b3afL48-R88)
* **Added `smooth_mls_2d` function**: Introduced a new function for 2D point smoothing using moving least-squares, with similar parameter handling and property preservation as `smooth_mls_1d`. (`src/napari_vedo_bridge/_points.py`, [src/napari_vedo_bridge/_points.pyL48-R88](diffhunk://#diff-54dbbd9453c28f9421c6b963083251446978e7cb794ab9567d2fa2cb2126b3afL48-R88))

### Updates to tests:

* **Expanded test coverage**: Added tests for the new `smooth_mls_2d` function to ensure its functionality and output consistency. (`src/napari_vedo_bridge/_tests/test_points.py`, [[1]](diffhunk://#diff-e393fa2b973edc09942badc81b4b462170dec1fca651df4d62d7d2cfe30c5c7aL3-R3) [[2]](diffhunk://#diff-e393fa2b973edc09942badc81b4b462170dec1fca651df4d62d7d2cfe30c5c7aR16-R18)

### Updates to YAML configuration:

* **Refined contributions metadata**: Updated the `napari.yaml` file to include separate entries for `smooth_points_1d` and `smooth_points_2d`, replacing the previous generic `smooth_points` entry. Adjusted command references and display names accordingly. (`src/napari_vedo_bridge/napari.yaml`, [[1]](diffhunk://#diff-378d06f376911f442dd5f06020e1214f5959b10fd23de207f3b1cb83c6e46302L60-R65) [[2]](diffhunk://#diff-378d06f376911f442dd5f06020e1214f5959b10fd23de207f3b1cb83c6e46302L148-R154) [[3]](diffhunk://#diff-378d06f376911f442dd5f06020e1214f5959b10fd23de207f3b1cb83c6e46302L176-R182)