### PR TITLE
use git tags for versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ testing = [
 "User Support" = "https://github.com/jo-mueller/napari-vedo-bridge/issues"
 
 [build-system]
-requires = ["setuptools>=42.0.0", "wheel"]
+requires = ["setuptools>=42.0.0", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -65,8 +65,9 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]
 
-[tool.setuptools.dynamic]
-version = {attr = "napari_vedo_bridge.__version__"}
+[tool.setuptools_scm]
+write_to = "src/napari_vedo_bridge/_version.py"
+fallback_version = "0.0.1+nogit"
 
 [tool.black]
 line-length = 79

--- a/src/napari_vedo_bridge/__init__.py
+++ b/src/napari_vedo_bridge/__init__.py
@@ -1,5 +1,3 @@
-__version__ = "0.2.2"
-
 from ._mesh import (
     compute_normals,
     shrink,


### PR DESCRIPTION
This pull request updates the versioning system for the `napari-vedo-bridge` package by transitioning from a manually defined version to an automated versioning approach using `setuptools_scm`. It also removes the hardcoded version from the `__init__.py` file.

Versioning system updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L56-R56): Added `setuptools_scm` to the `requires` field under `[build-system]` to enable automated versioning.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L68-R70): Replaced the `[tool.setuptools.dynamic]` configuration for versioning with `[tool.setuptools_scm]`, specifying `write_to` and `fallback_version` for version management.

Code cleanup:

* [`src/napari_vedo_bridge/__init__.py`](diffhunk://#diff-824374665a9d0343892f14437153d0024d4b219ee498107129a87922f641aee3L1-L2): Removed the hardcoded `__version__` variable to rely on `setuptools_scm` for versioning.